### PR TITLE
fix: Apply correct gofmt formatting to ACP files

### DIFF
--- a/pkg/acp/acp_config_loader.go
+++ b/pkg/acp/acp_config_loader.go
@@ -7,8 +7,8 @@ package acp
 
 import (
 	"fmt"
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -25,11 +25,11 @@ func NewConfigLoader() *ConfigLoader {
 // LoadConfig loads ACP configuration from a YAML file
 func (cl *ConfigLoader) LoadConfig(path string) (*ACPGuardConfig, error) {
 	// Validate path to prevent file inclusion attacks
-		sanitizedPath := filepath.Clean(path)
-		if !strings.HasPrefix(sanitizedPath, "/") && !strings.HasPrefix(sanitizedPath, "./") && !strings.HasPrefix(sanitizedPath, "../") {
-			return nil, fmt.Errorf("invalid config path: path must be absolute or relative")
-		}
-		data, err := os.ReadFile(sanitizedPath)
+	sanitizedPath := filepath.Clean(path)
+	if !strings.HasPrefix(sanitizedPath, "/") && !strings.HasPrefix(sanitizedPath, "./") && !strings.HasPrefix(sanitizedPath, "../") {
+		return nil, fmt.Errorf("invalid config path: path must be absolute or relative")
+	}
+	data, err := os.ReadFile(sanitizedPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}

--- a/pkg/acp/acp_middleware.go
+++ b/pkg/acp/acp_middleware.go
@@ -119,8 +119,8 @@ func (m *Middleware) WrapHandler(handler http.Handler) http.Handler {
 
 		// Write response
 		if _, writeErr := w.Write(wrapper.buffer.Bytes()); writeErr != nil {
-				m.logger.Error("Failed to write response", "error", writeErr)
-			}
+			m.logger.Error("Failed to write response", "error", writeErr)
+		}
 	})
 }
 


### PR DESCRIPTION
Apply proper gofmt formatting to resolve Security workflow failure.

Files: pkg/acp/acp_middleware.go, pkg/acp/acp_config_loader.go