### PR TITLE
fix(trust/score): resolve data race in InMemoryBaseline.GetBaseline

### DIFF
--- a/pkg/compliance/atlas_coverage_test.go
+++ b/pkg/compliance/atlas_coverage_test.go
@@ -249,7 +249,17 @@ func TestAtlas_Check_SpecialCharacters(t *testing.T) {
 	_ = findings
 }
 
-// TestAtlas_Check_Timing tests that Check doesn't hang
+// TestAtlas_Check_Timing tests that Check doesn't hang.
+//
+// v3.2.0 Phase 8: bumped limit from 5s to 10s. The test is wall-clock
+// sensitive and was observed to flake on busy CI runners (5.68s observed
+// vs 5s limit). 10s gives 2x headroom while still catching any
+// catastrophic hang. 1000 iterations of string concat + regex matching
+// is fast (sub-second on modern hardware) but variable on shared CI.
+//
+// If this test ever flakes above 10s, the right fix is to investigate
+// the Check implementation for performance regressions, not to bump
+// the limit further.
 func TestAtlas_Check_Timing(t *testing.T) {
 	f := NewATLASFramework(0)
 
@@ -266,8 +276,8 @@ func TestAtlas_Check_Timing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Check should not error: %v", err)
 	}
-	if elapsed > 5*time.Second {
-		t.Errorf("Check took too long: %v", elapsed)
+	if elapsed > 10*time.Second {
+		t.Errorf("Check took too long: %v (limit: 10s, v3.2.0 Phase 8 fix)", elapsed)
 	}
 }
 

--- a/pkg/trust/score/baseline.go
+++ b/pkg/trust/score/baseline.go
@@ -68,7 +68,13 @@ func (b *InMemoryBaseline) GetBaseline(ctx context.Context, agentID string) (*Ba
 	if !exists {
 		return &BaselineMetrics{AgentID: agentID, LastUpdated: time.Now().UTC()}, nil
 	}
-	return baseline, nil
+	// v3.2.0 Phase 8 race fix: return a deep copy so the caller can read the
+	// fields (TotalEvents, SuccessRate, etc.) without holding b.mu. The map
+	// stores a single *BaselineMetrics that updateBaselineLocked mutates in
+	// place; returning that pointer directly causes a data race when
+	// RecordEvent and Calculate run concurrently on the same agent.
+	copy := *baseline
+	return &copy, nil
 }
 
 func (b *InMemoryBaseline) UpdateBaseline(ctx context.Context, agentID string) error {

--- a/pkg/trust/score/race_regression_test.go
+++ b/pkg/trust/score/race_regression_test.go
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// AegisGate Platform - Race regression test for trust/score baseline access
+//
+// v3.2.0 Phase 8: This test pins the contract that GetBaseline returns a
+// snapshot of BaselineMetrics that is safe to read WITHOUT holding the
+// baseline engine's mutex. Prior to the Phase 8 fix, GetBaseline returned
+// a pointer to the same struct stored in the internal map; concurrent
+// RecordEvent calls (which mutate the struct in place) raced with
+// Calculate's reads.
+
+package score
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestGetBaseline_ReturnsCopyNotPointer is a focused regression test for
+// the Phase 8 race fix. It verifies that mutating the returned pointer
+// does not affect the engine's internal state — i.e., GetBaseline
+// returns a value copy wrapped in a pointer, not a pointer to the
+// internal map entry.
+func TestGetBaseline_ReturnsCopyNotPointer(t *testing.T) {
+	engine := NewBaselineEngine(100)
+
+	// Seed with one event so the baseline exists in the map.
+	err := engine.RecordEvent(context.Background(), &BehaviorEvent{
+		ID:      "evt-1",
+		AgentID: "agent-x",
+		Type:    EventCapabilityAllowed,
+	})
+	if err != nil {
+		t.Fatalf("RecordEvent: %v", err)
+	}
+
+	// Get the baseline (caller's copy).
+	baseline, err := engine.GetBaseline(context.Background(), "agent-x")
+	if err != nil {
+		t.Fatalf("GetBaseline: %v", err)
+	}
+	if baseline == nil {
+		t.Fatal("GetBaseline returned nil")
+	}
+	if baseline.TotalEvents != 1 {
+		t.Fatalf("expected TotalEvents=1, got %d", baseline.TotalEvents)
+	}
+
+	// Mutate the caller's copy. This MUST NOT affect the engine's
+	// internal state. If GetBaseline returned a pointer to the internal
+	// map entry, this would corrupt the engine.
+	baseline.TotalEvents = 9999
+	baseline.SuccessRate = -1.0
+
+	// Record another event. The engine's internal state should still
+	// track from 1 (not 9999) because the previous mutation was local.
+	err = engine.RecordEvent(context.Background(), &BehaviorEvent{
+		ID:      "evt-2",
+		AgentID: "agent-x",
+		Type:    EventCapabilityAllowed,
+	})
+	if err != nil {
+		t.Fatalf("RecordEvent 2: %v", err)
+	}
+
+	// Get the baseline fresh. TotalEvents should be 2 (one initial + one
+	// new), proving the engine's internal state was not corrupted by
+	// the caller's earlier mutation.
+	fresh, err := engine.GetBaseline(context.Background(), "agent-x")
+	if err != nil {
+		t.Fatalf("GetBaseline (fresh): %v", err)
+	}
+	if fresh.TotalEvents != 2 {
+		t.Errorf("engine state was corrupted by caller mutation: TotalEvents=%d, want 2", fresh.TotalEvents)
+	}
+	if fresh.SuccessRate != 1.0 {
+		t.Errorf("SuccessRate wrong: got %f, want 1.0 (both events allowed)", fresh.SuccessRate)
+	}
+}
+
+// TestGetBaseline_ConcurrentReadAndWrite exercises the exact race that
+// Phase 8 fixes: one goroutine reading baselines in a tight loop while
+// another goroutine writes events. Run with `go test -race`. The test
+// itself does not assert a specific value; the race detector will fail
+// the test if GetBaseline does not return a snapshot copy.
+func TestGetBaseline_ConcurrentReadAndWrite(t *testing.T) {
+	engine := NewBaselineEngine(1000)
+
+	// Seed the engine so the baseline exists.
+	err := engine.RecordEvent(context.Background(), &BehaviorEvent{
+		ID:      "evt-seed",
+		AgentID: "agent-y",
+		Type:    EventCapabilityAllowed,
+	})
+	if err != nil {
+		t.Fatalf("RecordEvent seed: %v", err)
+	}
+
+	const writeCount = 500
+	var readerWG sync.WaitGroup
+	var writerWG sync.WaitGroup
+
+	// Reader goroutine: calls GetBaseline repeatedly for the entire
+	// duration of the writer's run.
+	readerWG.Add(1)
+	go func() {
+		defer readerWG.Done()
+		for i := 0; i < writeCount*4; i++ {
+			baseline, err := engine.GetBaseline(context.Background(), "agent-y")
+			if err != nil {
+				t.Errorf("GetBaseline: %v", err)
+				return
+			}
+			// Read several fields. With the bug, this would race with
+			// the writer's struct mutation.
+			_ = baseline.TotalEvents
+			_ = baseline.SuccessRate
+			_ = baseline.AllowedCount
+		}
+	}()
+
+	// Writer goroutine: records events.
+	writerWG.Add(1)
+	go func() {
+		defer writerWG.Done()
+		for i := 0; i < writeCount; i++ {
+			err := engine.RecordEvent(context.Background(), &BehaviorEvent{
+				ID:      "evt-" + string(rune('a'+i%26)),
+				AgentID: "agent-y",
+				Type:    EventCapabilityAllowed,
+			})
+			if err != nil {
+				t.Errorf("RecordEvent: %v", err)
+				return
+			}
+		}
+	}()
+
+	// Wait for both to finish.
+	writerWG.Wait()
+	readerWG.Wait()
+}


### PR DESCRIPTION
## v3.2.0 Phase 8: pre-existing bug fixes

Two pre-existing issues that affected CI are fixed in this PR. These are the bugs documented in `aegisgate-v3.2.0-pre-existing-issues` (memory entry).

### Issue 1: Data race in `pkg/trust/score`

`InMemoryBaseline.GetBaseline` returned a pointer to the same `*BaselineMetrics` struct stored in the engine's internal map. The struct was also mutated in place by `updateBaselineLocked` (called from `RecordEvent`). With concurrent `RecordEvent` and `Calculate` callers, this caused a data race:

```
WARNING: DATA RACE
Write at 0x00c000228d30 by goroutine 91:
  InMemoryBaseline.updateBaselineLocked()  baseline.go:146
  InMemoryBaseline.RecordEvent()           baseline.go:59
  Engine.RecordEvent()                     engine.go:56

Previous read at 0x00c000228d30 by goroutine 90:
  Calculator.calculateBehaviorMultiplier() calculator.go:113
  Calculator.Calculate()                   calculator.go:43
  Engine.calculateAndStoreScore()          engine.go:157
  Engine.RecordEvent()                     engine.go:61
```

This was the race that caused the **previous v3.2.0 attempt to be reverted** (see `plans/SESSION_ANCHOR.md`).

**Fix:** `GetBaseline` now returns a **deep copy** of the struct (all fields are value types: int64, float64, time.Time, string). The caller can read without holding the engine's mutex.

**Tests added** (`pkg/trust/score/race_regression_test.go`, 142 lines):
- `TestGetBaseline_ReturnsCopyNotPointer` — sequential test that mutates the caller's copy and verifies the engine's internal state is unaffected.
- `TestGetBaseline_ConcurrentReadAndWrite` — concurrent reader + writer under `-race` detector. **Fails with "race detected" if the fix is reverted** (verified by reverting locally and re-running).

### Issue 2: `TestAtlas_Check_Timing` flake in `pkg/compliance/atlas_coverage_test.go`

The test asserted `elapsed < 5s` but was observed to take 5.68s on busy CI runners.

**Fix:** Bumped the limit to `10s` (2x headroom) and added a comment explaining the choice and what to do if it ever flakes above 10s (investigate `Check`'s performance, not bump further).

### Test results

| Command | Result |
|---|---|
| `go test -race -count=1 ./pkg/trust/score/...` | ✅ PASS (1.05s) |
| `go test -race -count=1 ./pkg/trust/...` (all 5 sub-packages) | ✅ PASS |
| `go test -race -count=1 ./pkg/compliance/...` (all 14 packages) | ✅ PASS (14.4s) |
| CI test command (coverage floor 80%) | ✅ PASS at 93.7% |
| `golangci-lint run` on changed packages | ✅ Clean |
| `govulncheck` on changed packages | ✅ 0 vulnerabilities |

### Files changed (3)

| File | Change |
|---|---|
| `pkg/trust/score/baseline.go` | `GetBaseline` returns deep copy |
| `pkg/trust/score/race_regression_test.go` | NEW: 142 lines, 2 tests, regression coverage |
| `pkg/compliance/atlas_coverage_test.go` | Bump timing limit 5s → 10s, add comment |

### Why this PR is small and unblocks Phase 4

Phase 4 (Trust Framework) will add concurrent attestation paths through `pkg/trust/score`. Without the Phase 8 fix, `go test -race ./pkg/trust/...` would fail intermittently under Phase 4's load. The race is the **only** known blocker between today and the start of Phase 4 (Module extraction is Phase 1, not blocked by this).

### Out of scope (deferred to other PRs)

- Issue 3: `aegisgate-platform` binary tracked in git → Phase 7 (housekeeping PR)
- Issues 4–7: `pkg/bridge`, `pkg/computeruse`, `pkg/trust/dashboard`, `pkg/sso` below 95% brand-promise coverage → not blocking v3.2.0

Refs: `plans/V3.2.0-ROADMAP.md` Section 3 Phase 8