### PR TITLE
feat(billing): fill in real Stripe module Price IDs

### DIFF
--- a/pkg/billing/billing-config.example.json
+++ b/pkg/billing/billing-config.example.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "v3.2.0 Phase 1.4: example/template file. Copy to billing-config.json and replace the PLACEHOLDER_* values with real Stripe Price IDs from https://dashboard.stripe.com/products. The tier_prices and tier_products (for the 5 main tiers) come pre-filled; only the 6 module_products need founder action.",
+  "_comment": "v3.2.0 Phase 1.4: example/template file. Copy to billing-config.json. All 6 module Stripe Price IDs are now live (filled in 2026-06-05); the live billing-config.json has the same values. The example is a reference; the live file is the source of truth at runtime.",
   "tier_prices": {
     "starter_annual": 29000,
     "starter_monthly": 2900,
@@ -49,52 +49,58 @@
   },
   "module_products": {
     "hipaa": {
-      "price_id": "PLACEHOLDER_MODULE_HIPAA",
-      "product_id": "PLACEHOLDER_MODULE_HIPAA_PROD",
+      "price_id": "price_1TeziTK2DQfk64XNIAfFuMKj",
+      "product_id": "prod_UeIJfrI764urCv",
       "lookup_key": "module_hipaa",
       "monthly_cents": 9900,
       "display_name": "HIPAA Compliance Module",
-      "required_tier": "developer"
+      "required_tier": "developer",
+      "buy_button_id": "buy_btn_1Tezs0K2DQfk64XNDj0YlFV9"
     },
     "pci": {
-      "price_id": "PLACEHOLDER_MODULE_PCI",
-      "product_id": "PLACEHOLDER_MODULE_PCI_PROD",
+      "price_id": "price_1TezizK2DQfk64XNd94jsOdw",
+      "product_id": "prod_UeIJlcjs02nOjQ",
       "lookup_key": "module_pci",
       "monthly_cents": 9900,
       "display_name": "PCI-DSS Compliance Module",
-      "required_tier": "developer"
+      "required_tier": "developer",
+      "buy_button_id": "buy_btn_1TezwsK2DQfk64XNNtCrVuxu"
     },
     "soc2": {
-      "price_id": "PLACEHOLDER_MODULE_SOC2",
-      "product_id": "PLACEHOLDER_MODULE_SOC2_PROD",
+      "price_id": "price_1TezkWK2DQfk64XNju4fvxiz",
+      "product_id": "prod_UeILCR5QPuIbdf",
       "lookup_key": "module_soc2",
       "monthly_cents": 14900,
       "display_name": "SOC 2 Compliance Module",
-      "required_tier": "developer"
+      "required_tier": "developer",
+      "buy_button_id": "buy_btn_1TezyiK2DQfk64XNMMKeyYQO"
     },
     "iso42001": {
-      "price_id": "PLACEHOLDER_MODULE_ISO42001",
-      "product_id": "PLACEHOLDER_MODULE_ISO42001_PROD",
+      "price_id": "price_1TeznbK2DQfk64XNG11q38xt",
+      "product_id": "prod_UeIOU5K1HCH3Vn",
       "lookup_key": "module_iso42001",
       "monthly_cents": 7900,
       "display_name": "ISO 42001 AI Compliance Module",
-      "required_tier": "professional"
+      "required_tier": "professional",
+      "buy_button_id": "buy_btn_1Tf00WK2DQfk64XN0EvRqZcy"
     },
     "fedramp": {
-      "price_id": "PLACEHOLDER_MODULE_FEDRAMP",
-      "product_id": "PLACEHOLDER_MODULE_FEDRAMP_PROD",
+      "price_id": "price_1Tezp9K2DQfk64XNyX2vR5nj",
+      "product_id": "prod_UeIPsk3H8PksXv",
       "lookup_key": "module_fedramp",
       "monthly_cents": 49900,
       "display_name": "FedRAMP Compliance Module",
-      "required_tier": "professional"
+      "required_tier": "professional",
+      "buy_button_id": "buy_btn_1Tf01sK2DQfk64XNvjoZTO32"
     },
     "fips": {
-      "price_id": "PLACEHOLDER_MODULE_FIPS",
-      "product_id": "PLACEHOLDER_MODULE_FIPS_PROD",
+      "price_id": "price_1Tezq5K2DQfk64XN0mNGglT9",
+      "product_id": "prod_UeIQ5haHNP9U4w",
       "lookup_key": "module_fips",
       "monthly_cents": 29900,
       "display_name": "FIPS 140-2/140-3 Compliance Module",
-      "required_tier": "professional"
+      "required_tier": "professional",
+      "buy_button_id": "buy_btn_1Tf04ZK2DQfk64XNItWmUatb"
     }
   },
   "stripe_config": {
@@ -124,6 +130,30 @@
       "professional_monthly": {
         "product_id": "prod_UeHWXXQHJ83JXW",
         "name": "AegisGate Security Platform - Professional Tier (monthly)"
+      },
+      "module_hipaa": {
+        "product_id": "prod_UeIJfrI764urCv",
+        "name": "HIPAA Compliance Module (recurring)"
+      },
+      "module_pci": {
+        "product_id": "prod_UeIJlcjs02nOjQ",
+        "name": "PCI-DSS Compliance Module (recurring)"
+      },
+      "module_soc2": {
+        "product_id": "prod_UeILCR5QPuIbdf",
+        "name": "SOC 2 Compliance Module (recurring)"
+      },
+      "module_iso42001": {
+        "product_id": "prod_UeIOU5K1HCH3Vn",
+        "name": "ISO 42001 AI Compliance Module (recurring)"
+      },
+      "module_fedramp": {
+        "product_id": "prod_UeIPsk3H8PksXv",
+        "name": "FedRAMP Compliance Module (recurring)"
+      },
+      "module_fips": {
+        "product_id": "prod_UeIQ5haHNP9U4w",
+        "name": "FIPS 140-2/140-3 Compliance Module (recurring)"
       }
     }
   }

--- a/pkg/billing/billing-config.json
+++ b/pkg/billing/billing-config.json
@@ -1,5 +1,5 @@
 {
-  "_comment_v3.2.0": "v3.2.0 Phase 1.4: Updated with live Stripe Price IDs (2026-06-05). Tier Prices were regenerated in the Stripe dashboard. Module Price IDs are PLACEHOLDER_* — the founder will fill these in from https://dashboard.stripe.com/products as part of the module rollout. The webhook (Phase 1.3) reads lookup_key and unit_amount from the line item directly, so module purchases work even with placeholder price_id values.",
+  "_comment_v3.2.0": "v3.2.0 Phase 1.4: Updated with live Stripe Price IDs (2026-06-05). Tier Prices and 6 module Prices are all live in the Stripe dashboard. The webhook (Phase 1.3) reads lookup_key and unit_amount from the line item directly. Price IDs in this file are for invoice/audit-trail reconciliation and the customer portal.",
   "tier_prices": {
     "starter_annual": 29000,
     "starter_monthly": 2900,
@@ -49,58 +49,58 @@
   },
   "module_products": {
     "hipaa": {
-      "price_id": "PLACEHOLDER_MODULE_HIPAA",
-      "product_id": "PLACEHOLDER_MODULE_HIPAA_PROD",
+      "price_id": "price_1TeziTK2DQfk64XNIAfFuMKj",
+      "product_id": "prod_UeIJfrI764urCv",
       "lookup_key": "module_hipaa",
       "monthly_cents": 9900,
       "display_name": "HIPAA Compliance Module",
       "required_tier": "developer",
-      "_comment": "Founder TODO: create HIPAA Module product in Stripe dashboard. Set lookup_key to 'module_hipaa'. Set unit_amount to 9900 (cents). Replace PLACEHOLDER_* values."
+      "buy_button_id": "buy_btn_1Tezs0K2DQfk64XNDj0YlFV9"
     },
     "pci": {
-      "price_id": "PLACEHOLDER_MODULE_PCI",
-      "product_id": "PLACEHOLDER_MODULE_PCI_PROD",
+      "price_id": "price_1TezizK2DQfk64XNd94jsOdw",
+      "product_id": "prod_UeIJlcjs02nOjQ",
       "lookup_key": "module_pci",
       "monthly_cents": 9900,
       "display_name": "PCI-DSS Compliance Module",
       "required_tier": "developer",
-      "_comment": "Founder TODO: create PCI-DSS Module product. lookup_key: 'module_pci'. unit_amount: 9900."
+      "buy_button_id": "buy_btn_1TezwsK2DQfk64XNNtCrVuxu"
     },
     "soc2": {
-      "price_id": "PLACEHOLDER_MODULE_SOC2",
-      "product_id": "PLACEHOLDER_MODULE_SOC2_PROD",
+      "price_id": "price_1TezkWK2DQfk64XNju4fvxiz",
+      "product_id": "prod_UeILCR5QPuIbdf",
       "lookup_key": "module_soc2",
       "monthly_cents": 14900,
       "display_name": "SOC 2 Compliance Module",
       "required_tier": "developer",
-      "_comment": "Founder TODO: create SOC 2 Module product. lookup_key: 'module_soc2'. unit_amount: 14900."
+      "buy_button_id": "buy_btn_1TezyiK2DQfk64XNMMKeyYQO"
     },
     "iso42001": {
-      "price_id": "PLACEHOLDER_MODULE_ISO42001",
-      "product_id": "PLACEHOLDER_MODULE_ISO42001_PROD",
+      "price_id": "price_1TeznbK2DQfk64XNG11q38xt",
+      "product_id": "prod_UeIOU5K1HCH3Vn",
       "lookup_key": "module_iso42001",
       "monthly_cents": 7900,
       "display_name": "ISO 42001 AI Compliance Module",
       "required_tier": "professional",
-      "_comment": "Founder TODO: create ISO 42001 Module product. lookup_key: 'module_iso42001'. unit_amount: 7900."
+      "buy_button_id": "buy_btn_1Tf00WK2DQfk64XN0EvRqZcy"
     },
     "fedramp": {
-      "price_id": "PLACEHOLDER_MODULE_FEDRAMP",
-      "product_id": "PLACEHOLDER_MODULE_FEDRAMP_PROD",
+      "price_id": "price_1Tezp9K2DQfk64XNyX2vR5nj",
+      "product_id": "prod_UeIPsk3H8PksXv",
       "lookup_key": "module_fedramp",
       "monthly_cents": 49900,
       "display_name": "FedRAMP Compliance Module",
       "required_tier": "professional",
-      "_comment": "Founder TODO: create FedRAMP Module product. lookup_key: 'module_fedramp'. unit_amount: 49900."
+      "buy_button_id": "buy_btn_1Tf01sK2DQfk64XNvjoZTO32"
     },
     "fips": {
-      "price_id": "PLACEHOLDER_MODULE_FIPS",
-      "product_id": "PLACEHOLDER_MODULE_FIPS_PROD",
+      "price_id": "price_1Tezq5K2DQfk64XN0mNGglT9",
+      "product_id": "prod_UeIQ5haHNP9U4w",
       "lookup_key": "module_fips",
       "monthly_cents": 29900,
       "display_name": "FIPS 140-2/140-3 Compliance Module",
       "required_tier": "professional",
-      "_comment": "Founder TODO: create FIPS Module product. lookup_key: 'module_fips'. unit_amount: 29900."
+      "buy_button_id": "buy_btn_1Tf04ZK2DQfk64XNItWmUatb"
     }
   },
   "stripe_config": {
@@ -130,6 +130,30 @@
       "professional_monthly": {
         "product_id": "prod_UeHWXXQHJ83JXW",
         "name": "AegisGate Security Platform - Professional Tier (monthly)"
+      },
+      "module_hipaa": {
+        "product_id": "prod_UeIJfrI764urCv",
+        "name": "HIPAA Compliance Module (recurring)"
+      },
+      "module_pci": {
+        "product_id": "prod_UeIJlcjs02nOjQ",
+        "name": "PCI-DSS Compliance Module (recurring)"
+      },
+      "module_soc2": {
+        "product_id": "prod_UeILCR5QPuIbdf",
+        "name": "SOC 2 Compliance Module (recurring)"
+      },
+      "module_iso42001": {
+        "product_id": "prod_UeIOU5K1HCH3Vn",
+        "name": "ISO 42001 AI Compliance Module (recurring)"
+      },
+      "module_fedramp": {
+        "product_id": "prod_UeIPsk3H8PksXv",
+        "name": "FedRAMP Compliance Module (recurring)"
+      },
+      "module_fips": {
+        "product_id": "prod_UeIQ5haHNP9U4w",
+        "name": "FIPS 140-2/140-3 Compliance Module (recurring)"
       }
     }
   }

--- a/pkg/billing/billing_config_schema_test.go
+++ b/pkg/billing/billing_config_schema_test.go
@@ -121,6 +121,7 @@ func TestBillingConfig_TierProducts(t *testing.T) {
 				t.Fatalf("tier_products.%s should be a rich object, got %T", key, val)
 			}
 			required := []string{"price_id", "product_id", "lookup_key", "buy_button_id"}
+			_ = required // see TestBillingConfig_ModuleProducts for the module variant
 			for _, field := range required {
 				if obj[field] == nil || obj[field] == "" {
 					t.Errorf("tier_products.%s missing %q field", key, field)
@@ -174,7 +175,7 @@ func TestBillingConfig_ModuleProducts(t *testing.T) {
 				t.Fatalf("module_products.%s should be an object, got %T", key, val)
 			}
 			// Required fields.
-			for _, field := range []string{"lookup_key", "monthly_cents", "display_name", "required_tier"} {
+			for _, field := range []string{"price_id", "product_id", "lookup_key", "buy_button_id", "monthly_cents", "display_name", "required_tier"} {
 				if obj[field] == nil {
 					t.Errorf("module_products.%s missing %q", key, field)
 				}
@@ -183,11 +184,16 @@ func TestBillingConfig_ModuleProducts(t *testing.T) {
 			if lk, _ := obj["lookup_key"].(string); lk != "module_"+key {
 				t.Errorf("module_products.%s.lookup_key = %q, want \"module_%s\"", key, lk, key)
 			}
-			// Price ID can be a PLACEHOLDER_* for v3.2.0 Phase 1.4 (founder
-			// is creating Stripe products in the background). Once the
-			// founder fills in real IDs, this check should be tightened.
-			if pid, _ := obj["price_id"].(string); pid != "" && !strings.HasPrefix(pid, "price_") && !strings.HasPrefix(pid, "PLACEHOLDER_") {
-				t.Errorf("module_products.%s.price_id = %q, want \"price_*\" or \"PLACEHOLDER_*\"", key, pid)
+			// Price ID must be a real Stripe price_ ID. v3.2.0 Phase 1.4
+			// started with PLACEHOLDER_* values during the founder's
+			// Stripe dashboard work; as of 2026-06-05 all 6 are filled
+			// in, so this is now strict.
+			if pid, _ := obj["price_id"].(string); !strings.HasPrefix(pid, "price_") {
+				t.Errorf("module_products.%s.price_id = %q, want \"price_*\" (PLACEHOLDER no longer allowed)", key, pid)
+			}
+			// buy_button_id must start with "buy_btn_".
+			if bid, _ := obj["buy_button_id"].(string); !strings.HasPrefix(bid, "buy_btn_") {
+				t.Errorf("module_products.%s.buy_button_id = %q, want \"buy_btn_*\"", key, bid)
 			}
 			// monthly_cents should be positive.
 			if cents, ok := obj["monthly_cents"].(float64); ok && cents <= 0 {
@@ -257,5 +263,44 @@ func TestBillingConfig_StarterConfig(t *testing.T) {
 	}
 	if v.StripeConfig.PublishableKey == "" {
 		t.Error("stripe_config.publishable_key is empty")
+	}
+}
+
+// TestBillingConfig_NoPlaceholders pins that all 6 module price_ids are
+// real (not PLACEHOLDER_*). As of 2026-06-05, all 6 modules have been
+// created in the Stripe dashboard and filled in here. This test ensures
+// no future commit accidentally re-introduces a placeholder.
+func TestBillingConfig_NoPlaceholders(t *testing.T) {
+	data, err := os.ReadFile("billing-config.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var v struct {
+		ModuleProducts map[string]struct {
+			PriceID   string `json:"price_id"`
+			ProductID string `json:"product_id"`
+		} `json:"module_products"`
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if len(v.ModuleProducts) != 6 {
+		t.Errorf("got %d module_products, want 6", len(v.ModuleProducts))
+	}
+	for name, m := range v.ModuleProducts {
+		t.Run(name, func(t *testing.T) {
+			if strings.HasPrefix(m.PriceID, "PLACEHOLDER") {
+				t.Errorf("module %s: price_id is still PLACEHOLDER: %q", name, m.PriceID)
+			}
+			if strings.HasPrefix(m.ProductID, "PLACEHOLDER") {
+				t.Errorf("module %s: product_id is still PLACEHOLDER: %q", name, m.ProductID)
+			}
+			if !strings.HasPrefix(m.PriceID, "price_") {
+				t.Errorf("module %s: price_id should start with 'price_', got %q", name, m.PriceID)
+			}
+			if !strings.HasPrefix(m.ProductID, "prod_") {
+				t.Errorf("module %s: product_id should start with 'prod_', got %q", name, m.ProductID)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fills in the 6 module product/price/buy_button IDs that the founder created in the Stripe dashboard on 2026-06-05. Tightens the schema test to reject PLACEHOLDER_* going forward. All webhook code from PR #60 works as-is — this just populates the live config.