### PR TITLE
feat(trust): Phase 4 (Trust Framework, 5th pillar) — sub-phases 4.1, 4.2

### DIFF
--- a/pkg/tier/tier.go
+++ b/pkg/tier/tier.go
@@ -412,6 +412,14 @@ const (
 	FeatureWhitelabel   Feature = "whitelabel"
 	FeatureCustomDomain Feature = "custom_domain"
 	FeatureVMSandbox    Feature = "mcp_vm_sandbox" // VM-level sandboxing
+	// v3.2.0 Phase 4: Trust Framework (5th pillar). The Trust pillar is the
+	// 5th architectural pillar of the platform (alongside HTTP Proxy, MCP,
+	// A2A, and Compliance). It provides cryptographic agent identity,
+	// per-session trust scoring, and signed attestations. Gated to
+	// Professional+ per the locked decision Q3. The signing primitives
+	// (Ed25519/ECDSA) exist in pkg/trust/attestation already; this feature
+	// flag enables them in the request lifecycle.
+	FeatureTrustPillar Feature = "trust_pillar"
 )
 
 // RequiredTier returns the minimum tier required for a feature
@@ -448,7 +456,8 @@ func RequiredTier(feature Feature) Tier {
 		FeatureSIEM, FeatureMultiTenant, FeaturePolicyEngine, FeatureDeptSeparation,
 		FeatureKubernetes, FeatureHelm,
 		FeaturePostgreSQL, FeatureS3, FeatureRetentionPol,
-		FeatureVaultSecrets, FeatureProcessSandbox:
+		FeatureVaultSecrets, FeatureProcessSandbox,
+		FeatureTrustPillar: // v3.2.0 Phase 4
 		return TierProfessional
 
 	// Enterprise
@@ -524,6 +533,8 @@ var featureKeyMap = map[string]Feature{
 	"deploy_autoscale": FeatureAutoScale, "deploy_multiregion": FeatureMultiRegion,
 	"storage_mongo": FeatureMongoDB, "whitelabel": FeatureWhitelabel,
 	"custom_domain": FeatureCustomDomain, "mcp_vm_sandbox": FeatureVMSandbox,
+	// v3.2.0 Phase 4: Trust Framework pillar
+	"trust_pillar": FeatureTrustPillar,
 }
 
 // TierHasFeatureKey checks if a tier has access to a feature given its string key.

--- a/pkg/tier/tier_test.go
+++ b/pkg/tier/tier_test.go
@@ -245,3 +245,51 @@ func TestAllFeatures(t *testing.T) {
 		t.Errorf("Total features should be at least 50, got %d", len(all))
 	}
 }
+
+// TestTrustPillar_TierMapping verifies the v3.2.0 Phase 4 Trust Framework
+// feature gate. Per the locked decision Q3, the Trust pillar is
+// Professional+ only. The signing primitives (Ed25519/ECDSA) are always
+// available as a Go library (pkg/trust/), but the *enforcement* (the
+// 5th-pillar runtime behavior) is gated to Professional and above.
+func TestTrustPillar_TierMapping(t *testing.T) {
+	// RequiredTier is Professional (NOT Enterprise — this is the second
+	// pillar after Compliance to land at Pro).
+	required := RequiredTier(FeatureTrustPillar)
+	if required != TierProfessional {
+		t.Errorf("FeatureTrustPillar required tier = %s, want Professional (per Q3 lock)", required)
+	}
+
+	// Community and Starter do NOT have the pillar.
+	for _, tier := range []Tier{TierCommunity, TierStarter} {
+		if HasFeature(tier, FeatureTrustPillar) {
+			t.Errorf("tier %s should NOT have FeatureTrustPillar (per Q3 lock)", tier)
+		}
+	}
+	// Developer does NOT have the pillar (gate is at Professional, not Dev).
+	if HasFeature(TierDeveloper, FeatureTrustPillar) {
+		t.Error("Developer should NOT have FeatureTrustPillar (gate is at Professional)")
+	}
+	// Professional and Enterprise DO have the pillar.
+	for _, tier := range []Tier{TierProfessional, TierEnterprise} {
+		if !HasFeature(tier, FeatureTrustPillar) {
+			t.Errorf("tier %s should have FeatureTrustPillar (per Q3 lock)", tier)
+		}
+	}
+}
+
+// TestTrustPillar_FeatureKey verifies the string key resolves to the
+// expected Feature constant. The key "trust_pillar" is the canonical
+// name used in feature negotiation (middleware, contract YAML, etc.).
+func TestTrustPillar_FeatureKey(t *testing.T) {
+	f, ok := FeatureForKey("trust_pillar")
+	if !ok {
+		t.Fatal("FeatureForKey(\"trust_pillar\") returned ok=false")
+	}
+	if f != FeatureTrustPillar {
+		t.Errorf("FeatureForKey(\"trust_pillar\") = %v, want FeatureTrustPillar", f)
+	}
+	// Unknown key returns false.
+	if _, ok := FeatureForKey("nonexistent_pillar"); ok {
+		t.Error("FeatureForKey(\"nonexistent_pillar\") should return ok=false")
+	}
+}

--- a/pkg/trust/session.go
+++ b/pkg/trust/session.go
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: Apache-2.0
+// AegisGate Platform - Trust Session Manager (v3.2.0 Phase 4)
+//
+// session.go adds request-lifecycle session semantics on top of the
+// per-agent score engine (pkg/trust/score.Engine). The Engine keys
+// everything by agentID (long-lived identity); this package keys by
+// sessionID (short-lived request lifecycle: an MCP connection, an
+// A2A agent-to-agent conversation, a proxy request, etc.).
+//
+// The two together give us:
+//   - Engine.GetScore(agentID)   -> lifetime trust score for the agent
+//   - Session.ScoreDelta(sessID) -> how much the score changed during
+//                                   this specific request
+//
+// v3.2.0 Phase 4.2. The HTTP API in pkg/trust/api.go (Phase 4.3) and
+// the protocol wiring in mcpserver/a2a/proxy/response (Phase 4.4) will
+// both use this package.
+
+package trust
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/aegisgatesecurity/aegisgate-platform/pkg/trust/score"
+	"github.com/google/uuid"
+)
+
+// ErrSessionNotFound is returned when a session ID has no live session.
+var ErrSessionNotFound = errors.New("trust session not found")
+
+// ErrSessionAlreadyEnded is returned when an operation is attempted on
+// a session that has already been ended (closed).
+var ErrSessionAlreadyEnded = errors.New("trust session already ended")
+
+// Session represents a request-lifecycle trust session.
+//
+// Lifecycle:
+//  1. Created via Manager.Start(agentID) — StartedAt is set
+//  2. Events recorded via Manager.Record(sessionID, event)
+//  3. Closed via Manager.End(sessionID) — EndedAt is set, session
+//     stays in the map for historical queries but is no longer "live"
+type Session struct {
+	ID           string                 `json:"id"`
+	AgentID      string                 `json:"agentId"`
+	StartedAt    time.Time              `json:"startedAt"`
+	EndedAt      time.Time              `json:"endedAt,omitempty"` // zero = still open
+	InitialScore float64                `json:"initialScore"`      // snapshot at Start
+	Events       []*score.BehaviorEvent `json:"events,omitempty"`  // events recorded during this session
+	Metadata     map[string]string      `json:"metadata,omitempty"`
+}
+
+// IsActive returns true if the session has been started but not ended.
+func (s *Session) IsActive() bool {
+	return !s.StartedAt.IsZero() && s.EndedAt.IsZero()
+}
+
+// Duration returns the wall-clock duration of the session.
+// If the session is still active, returns time since StartedAt.
+func (s *Session) Duration() time.Duration {
+	if s.StartedAt.IsZero() {
+		return 0
+	}
+	end := s.EndedAt
+	if end.IsZero() {
+		end = time.Now()
+	}
+	return end.Sub(s.StartedAt)
+}
+
+// EventCount returns the number of events recorded in this session.
+func (s *Session) EventCount() int {
+	return len(s.Events)
+}
+
+// Manager is the trust session manager. It is safe for concurrent use.
+//
+// Manager wraps a score.Engine and provides session-scoped queries on
+// top of the agent-lifetime scoring.
+//
+// Phase 4.2: a customer using the v3.2.0 Trust pillar (Professional+)
+// gets the Manager wired into their MCP/A2A/proxy/response paths
+// (Phase 4.4). Below Pro+, the Manager exists in the code but is
+// not invoked.
+type Manager struct {
+	mu       sync.RWMutex
+	sessions map[string]*Session // sessionID -> Session
+	engine   *score.Engine
+	// maxSessions caps the in-memory session history. When exceeded,
+	// the oldest closed session is evicted (LRU-style). Default 10000.
+	maxSessions int
+	// maxSessionAge evicts closed sessions older than this. Default 24h.
+	maxSessionAge time.Duration
+}
+
+// ManagerConfig configures the Manager.
+type ManagerConfig struct {
+	// MaxSessions caps the in-memory session history. 0 = unlimited.
+	MaxSessions int
+	// MaxSessionAge is the max age of closed sessions before eviction.
+	// 0 = never evict.
+	MaxSessionAge time.Duration
+}
+
+// DefaultManagerConfig returns sensible defaults.
+func DefaultManagerConfig() *ManagerConfig {
+	return &ManagerConfig{
+		MaxSessions:   10000,
+		MaxSessionAge: 24 * time.Hour,
+	}
+}
+
+// NewManager creates a new trust session manager wrapping an existing
+// score.Engine. If config is nil, defaults are used.
+func NewManager(engine *score.Engine, config *ManagerConfig) *Manager {
+	if config == nil {
+		config = DefaultManagerConfig()
+	}
+	if engine == nil {
+		engine = score.NewEngine(nil)
+	}
+	return &Manager{
+		sessions:      make(map[string]*Session),
+		engine:        engine,
+		maxSessions:   config.MaxSessions,
+		maxSessionAge: config.MaxSessionAge,
+	}
+}
+
+// Engine returns the underlying score.Engine (for callers that need
+// direct access to lifetime scoring).
+func (m *Manager) Engine() *score.Engine {
+	return m.engine
+}
+
+// Start begins a new trust session for the given agent. Returns the
+// new Session with its assigned ID.
+//
+// The session's InitialScore is a snapshot of the agent's current
+// lifetime trust score at the moment the session starts. ScoreDelta
+// can be computed by comparing this to the current score at End time.
+func (m *Manager) Start(ctx context.Context, agentID string) (*Session, error) {
+	if agentID == "" {
+		return nil, errors.New("agent ID is required")
+	}
+	initialScore := 0.0
+	if s, err := m.engine.GetScore(ctx, agentID); err == nil && s != nil {
+		initialScore = s.Score
+	}
+	sess := &Session{
+		ID:           uuid.New().String(),
+		AgentID:      agentID,
+		StartedAt:    time.Now().UTC(),
+		InitialScore: initialScore,
+		Events:       make([]*score.BehaviorEvent, 0, 16),
+		Metadata:     make(map[string]string),
+	}
+	m.mu.Lock()
+	m.sessions[sess.ID] = sess
+	m.mu.Unlock()
+	// Evict if over cap.
+	m.evictIfNeeded()
+	return sess, nil
+}
+
+// StartWithMetadata is like Start but also attaches initial metadata
+// (e.g., source IP, MCP server name, A2A peer agent ID).
+func (m *Manager) StartWithMetadata(ctx context.Context, agentID string, metadata map[string]string) (*Session, error) {
+	sess, err := m.Start(ctx, agentID)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range metadata {
+		sess.Metadata[k] = v
+	}
+	return sess, nil
+}
+
+// Get returns the session with the given ID. Returns ErrSessionNotFound
+// if no such session exists.
+func (m *Manager) Get(sessionID string) (*Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	sess, ok := m.sessions[sessionID]
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	return sess, nil
+}
+
+// End closes the session. Subsequent calls to Record on the same
+// sessionID return ErrSessionAlreadyEnded. Returns the closed session
+// (so the caller can read the final state).
+func (m *Manager) End(ctx context.Context, sessionID string) (*Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sess, ok := m.sessions[sessionID]
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	if !sess.EndedAt.IsZero() {
+		return sess, ErrSessionAlreadyEnded
+	}
+	sess.EndedAt = time.Now().UTC()
+	return sess, nil
+}
+
+// Record appends a behavior event to the session AND forwards it to the
+// underlying score.Engine (which updates the agent's lifetime score).
+// Returns the recorded event with its assigned ID.
+func (m *Manager) Record(ctx context.Context, sessionID string, eventType score.EventType, capability string, severity int, description string) (*score.BehaviorEvent, error) {
+	m.mu.Lock()
+	sess, ok := m.sessions[sessionID]
+	m.mu.Unlock()
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	if !sess.IsActive() {
+		return nil, ErrSessionAlreadyEnded
+	}
+	// Forward to engine first (it may update the lifetime score).
+	if err := m.engine.RecordEvent(ctx, sess.AgentID, eventType, capability, severity, description); err != nil {
+		return nil, err
+	}
+	// Then append to the session.
+	event := &score.BehaviorEvent{
+		ID:          uuid.New().String(),
+		AgentID:     sess.AgentID,
+		Type:        eventType,
+		Capability:  capability,
+		Severity:    severity,
+		Description: description,
+		Timestamp:   time.Now().UTC(),
+	}
+	m.mu.Lock()
+	sess.Events = append(sess.Events, event)
+	m.mu.Unlock()
+	return event, nil
+}
+
+// Score returns the agent's current lifetime trust score as observed
+// during this session (live read from the engine).
+func (m *Manager) Score(ctx context.Context, sessionID string) (*score.TrustScore, error) {
+	m.mu.RLock()
+	sess, ok := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	return m.engine.GetScore(ctx, sess.AgentID)
+}
+
+// ScoreDelta returns the change in trust score during this session
+// (current score - initial score). Negative means the session eroded
+// trust; positive means it built trust. Returns 0 for an active
+// session whose first event hasn't moved the score yet.
+func (m *Manager) ScoreDelta(ctx context.Context, sessionID string) (float64, error) {
+	m.mu.RLock()
+	sess, ok := m.sessions[sessionID]
+	m.mu.RUnlock()
+	if !ok {
+		return 0, ErrSessionNotFound
+	}
+	current, err := m.engine.GetScore(ctx, sess.AgentID)
+	if err != nil {
+		return 0, err
+	}
+	if current == nil {
+		return 0, nil
+	}
+	return current.Score - sess.InitialScore, nil
+}
+
+// List returns all sessions, optionally filtered to active-only.
+// Sorted by StartedAt descending (newest first). Honors the
+// maxSessionAge config: closed sessions older than maxSessionAge
+// are excluded.
+func (m *Manager) List(activeOnly bool) []*Session {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]*Session, 0, len(m.sessions))
+	cutoff := time.Now().Add(-m.maxSessionAge)
+	for _, sess := range m.sessions {
+		if activeOnly && !sess.IsActive() {
+			continue
+		}
+		// Filter out closed sessions older than the cutoff.
+		if !sess.IsActive() && !sess.EndedAt.IsZero() && sess.EndedAt.Before(cutoff) && m.maxSessionAge > 0 {
+			continue
+		}
+		out = append(out, sess)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].StartedAt.After(out[j].StartedAt)
+	})
+	return out
+}
+
+// ListByAgent returns all sessions for the given agent, sorted by
+// StartedAt descending.
+func (m *Manager) ListByAgent(agentID string, activeOnly bool) []*Session {
+	all := m.List(activeOnly)
+	out := make([]*Session, 0, len(all))
+	for _, s := range all {
+		if s.AgentID == agentID {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// ActiveCount returns the number of currently-open sessions.
+func (m *Manager) ActiveCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	n := 0
+	for _, s := range m.sessions {
+		if s.IsActive() {
+			n++
+		}
+	}
+	return n
+}
+
+// TotalCount returns the total number of sessions in memory (active + closed).
+func (m *Manager) TotalCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.sessions)
+}
+
+// evictIfNeeded evicts old closed sessions if we're over the cap.
+// Called after Start to keep the in-memory map bounded.
+func (m *Manager) evictIfNeeded() {
+	if m.maxSessions <= 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.sessions) <= m.maxSessions {
+		return
+	}
+	// Find closed sessions, oldest EndedAt first.
+	type entry struct {
+		id    string
+		ended time.Time
+	}
+	var closed []entry
+	for id, sess := range m.sessions {
+		if !sess.IsActive() {
+			closed = append(closed, entry{id: id, ended: sess.EndedAt})
+		}
+	}
+	// Sort oldest first.
+	sort.Slice(closed, func(i, j int) bool {
+		if closed[i].ended.IsZero() {
+			return false
+		}
+		if closed[j].ended.IsZero() {
+			return true
+		}
+		return closed[i].ended.Before(closed[j].ended)
+	})
+	// Evict the oldest until under cap.
+	excess := len(m.sessions) - m.maxSessions
+	for i := 0; i < excess && i < len(closed); i++ {
+		delete(m.sessions, closed[i].id)
+	}
+}

--- a/pkg/trust/session_test.go
+++ b/pkg/trust/session_test.go
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: Apache-2.0
+// AegisGate Platform - Trust Session Manager tests (v3.2.0 Phase 4.2)
+//
+// Tests the request-lifecycle session wrapper on top of score.Engine.
+
+package trust
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aegisgatesecurity/aegisgate-platform/pkg/trust/score"
+)
+
+// discardSession returns a Manager with a small cap for testing.
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+	engine := score.NewEngine(nil)
+	return NewManager(engine, &ManagerConfig{
+		MaxSessions:   100,
+		MaxSessionAge: 1 * time.Hour,
+	})
+}
+
+func TestManager_Start_AssignsIDAndInitialScore(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, err := m.Start(ctx, "agent-1")
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if sess.ID == "" {
+		t.Error("session ID is empty")
+	}
+	if sess.AgentID != "agent-1" {
+		t.Errorf("agentID = %q, want agent-1", sess.AgentID)
+	}
+	if sess.StartedAt.IsZero() {
+		t.Error("StartedAt is zero")
+	}
+	if sess.EndedAt.IsZero() == false {
+		t.Error("EndedAt is set on a fresh session")
+	}
+	if !sess.IsActive() {
+		t.Error("freshly-started session is not IsActive()")
+	}
+	if sess.InitialScore != 100.0 {
+		// Default initial score is 100.0; engine returns that for a
+		// new agent (no events yet, no anomalies).
+		t.Errorf("InitialScore = %v, want 100.0", sess.InitialScore)
+	}
+}
+
+func TestManager_Start_RejectsEmptyAgentID(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.Start(context.Background(), "")
+	if err == nil {
+		t.Error("Start with empty agent ID returned no error")
+	}
+}
+
+func TestManager_Start_GeneratesUniqueIDs(t *testing.T) {
+	m := newTestManager(t)
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		s, _ := m.Start(context.Background(), "agent")
+		if seen[s.ID] {
+			t.Fatalf("duplicate session ID: %s", s.ID)
+		}
+		seen[s.ID] = true
+	}
+}
+
+func TestManager_Get_FoundAndNotFound(t *testing.T) {
+	m := newTestManager(t)
+	sess, _ := m.Start(context.Background(), "agent")
+	got, err := m.Get(sess.ID)
+	if err != nil {
+		t.Errorf("Get(%s): %v", sess.ID, err)
+	}
+	if got.ID != sess.ID {
+		t.Errorf("got.ID = %q, want %q", got.ID, sess.ID)
+	}
+	_, err = m.Get("nonexistent")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestManager_End_ClosesSession(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, _ := m.Start(ctx, "agent")
+	closed, err := m.End(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("End: %v", err)
+	}
+	if closed.EndedAt.IsZero() {
+		t.Error("EndedAt is zero after End")
+	}
+	if closed.IsActive() {
+		t.Error("closed session is still IsActive()")
+	}
+}
+
+func TestManager_End_ErrorsOnUnknownID(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.End(context.Background(), "nonexistent")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestManager_End_ErrorsOnAlreadyEnded(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, _ := m.Start(ctx, "agent")
+	_, _ = m.End(ctx, sess.ID)
+	_, err := m.End(ctx, sess.ID)
+	if !errors.Is(err, ErrSessionAlreadyEnded) {
+		t.Errorf("expected ErrSessionAlreadyEnded, got %v", err)
+	}
+}
+
+func TestManager_Record_AppendsAndForwards(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, _ := m.Start(ctx, "agent")
+	ev, err := m.Record(ctx, sess.ID, score.EventCapabilityAllowed, "read", 1, "test event")
+	if err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if ev.ID == "" {
+		t.Error("recorded event has no ID")
+	}
+	if ev.AgentID != "agent" {
+		t.Errorf("event.AgentID = %q, want agent", ev.AgentID)
+	}
+	if sess.EventCount() != 1 {
+		t.Errorf("EventCount = %d, want 1", sess.EventCount())
+	}
+	// Recording more events.
+	for i := 0; i < 5; i++ {
+		_, _ = m.Record(ctx, sess.ID, score.EventCapabilityAllowed, "read", 1, "test")
+	}
+	if sess.EventCount() != 6 {
+		t.Errorf("EventCount = %d, want 6", sess.EventCount())
+	}
+}
+
+func TestManager_Record_ErrorsOnClosedSession(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, _ := m.Start(ctx, "agent")
+	_, _ = m.End(ctx, sess.ID)
+	_, err := m.Record(ctx, sess.ID, score.EventCapabilityAllowed, "read", 1, "test")
+	if !errors.Is(err, ErrSessionAlreadyEnded) {
+		t.Errorf("expected ErrSessionAlreadyEnded, got %v", err)
+	}
+}
+
+func TestManager_Record_ErrorsOnUnknownSession(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.Record(context.Background(), "nonexistent", score.EventCapabilityAllowed, "read", 1, "test")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestManager_Score_ReturnsLifetimeScore(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, _ := m.Start(ctx, "agent")
+	ts, err := m.Score(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if ts == nil {
+		t.Fatal("Score returned nil")
+	}
+	if ts.AgentID != "agent" {
+		t.Errorf("TrustScore.AgentID = %q, want agent", ts.AgentID)
+	}
+}
+
+func TestManager_ScoreDelta_TracksChangeDuringSession(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, _ := m.Start(ctx, "agent")
+	initialDelta, err := m.ScoreDelta(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("ScoreDelta: %v", err)
+	}
+	if initialDelta != 0 {
+		t.Errorf("initial ScoreDelta = %v, want 0 (no events yet)", initialDelta)
+	}
+	// Record a denied event (negative impact on score).
+	_, _ = m.Record(ctx, sess.ID, score.EventCapabilityDenied, "write", 8, "denied")
+	delta, err := m.ScoreDelta(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("ScoreDelta after Record: %v", err)
+	}
+	// Delta should be negative (denied events erode trust).
+	if delta >= 0 {
+		t.Errorf("ScoreDelta after denied = %v, want < 0", delta)
+	}
+}
+
+func TestManager_StartWithMetadata(t *testing.T) {
+	m := newTestManager(t)
+	sess, err := m.StartWithMetadata(context.Background(), "agent", map[string]string{
+		"source_ip": "10.0.0.1",
+		"protocol":  "mcp",
+	})
+	if err != nil {
+		t.Fatalf("StartWithMetadata: %v", err)
+	}
+	if sess.Metadata["source_ip"] != "10.0.0.1" {
+		t.Errorf("metadata[source_ip] = %q, want 10.0.0.1", sess.Metadata["source_ip"])
+	}
+	if sess.Metadata["protocol"] != "mcp" {
+		t.Errorf("metadata[protocol] = %q, want mcp", sess.Metadata["protocol"])
+	}
+}
+
+func TestManager_List_AllAndActiveOnly(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	// 3 active sessions.
+	s1, _ := m.Start(ctx, "agent-1")
+	s2, _ := m.Start(ctx, "agent-2")
+	s3, _ := m.Start(ctx, "agent-3")
+	// Close one.
+	_, _ = m.End(ctx, s1.ID)
+	all := m.List(false)
+	if len(all) != 3 {
+		t.Errorf("List(all) returned %d, want 3", len(all))
+	}
+	active := m.List(true)
+	if len(active) != 2 {
+		t.Errorf("List(active) returned %d, want 2", len(active))
+	}
+	// Verify s1 is the closed one.
+	for _, s := range all {
+		if s.ID == s1.ID && s.IsActive() {
+			t.Error("s1 should be closed but IsActive()=true")
+		}
+	}
+	// Suppress unused warning.
+	_ = s2.ID
+	_ = s3.ID
+}
+
+func TestManager_ListByAgent(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	m.Start(ctx, "agent-1")
+	m.Start(ctx, "agent-1")
+	m.Start(ctx, "agent-2")
+	got := m.ListByAgent("agent-1", false)
+	if len(got) != 2 {
+		t.Errorf("ListByAgent(agent-1) = %d, want 2", len(got))
+	}
+	for _, s := range got {
+		if s.AgentID != "agent-1" {
+			t.Errorf("got session with agentID %q, want agent-1", s.AgentID)
+		}
+	}
+}
+
+func TestManager_ActiveCount(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	if got := m.ActiveCount(); got != 0 {
+		t.Errorf("ActiveCount = %d, want 0", got)
+	}
+	s1, _ := m.Start(ctx, "agent")
+	m.Start(ctx, "agent")
+	if got := m.ActiveCount(); got != 2 {
+		t.Errorf("ActiveCount = %d, want 2", got)
+	}
+	_, _ = m.End(ctx, s1.ID)
+	if got := m.ActiveCount(); got != 1 {
+		t.Errorf("ActiveCount after End = %d, want 1", got)
+	}
+}
+
+func TestManager_EvictionAtMaxSessions(t *testing.T) {
+	engine := score.NewEngine(nil)
+	m := NewManager(engine, &ManagerConfig{
+		MaxSessions:   3, // tiny cap to trigger eviction
+		MaxSessionAge: 1 * time.Hour,
+	})
+	ctx := context.Background()
+	// Create 5 sessions (all closed, all eligible for eviction).
+	for i := 0; i < 5; i++ {
+		s, _ := m.Start(ctx, "agent")
+		_, _ = m.End(ctx, s.ID)
+		// Sleep a bit to ensure distinct EndedAt timestamps.
+		time.Sleep(1 * time.Millisecond)
+	}
+	// Should have evicted down to 3.
+	if m.TotalCount() != 3 {
+		t.Errorf("TotalCount = %d, want 3 (after eviction)", m.TotalCount())
+	}
+}
+
+func TestSession_Duration(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	sess, _ := m.Start(ctx, "agent")
+	time.Sleep(10 * time.Millisecond)
+	if d := sess.Duration(); d < 10*time.Millisecond {
+		t.Errorf("Duration = %v, want >= 10ms", d)
+	}
+	_, _ = m.End(ctx, sess.ID)
+	d1 := sess.Duration()
+	time.Sleep(5 * time.Millisecond)
+	d2 := sess.Duration()
+	if d1 != d2 {
+		t.Errorf("closed session duration changed: %v -> %v", d1, d2)
+	}
+}
+
+func TestSession_IsActive(t *testing.T) {
+	// A zero-value session is not active.
+	var s Session
+	if s.IsActive() {
+		t.Error("zero-value Session is IsActive()=true (should be false)")
+	}
+	s.StartedAt = time.Now()
+	if !s.IsActive() {
+		t.Error("Session with only StartedAt should be IsActive()")
+	}
+	s.EndedAt = time.Now()
+	if s.IsActive() {
+		t.Error("Session with EndedAt set should not be IsActive()")
+	}
+}
+
+func TestManager_Engine_ReturnsUnderlyingEngine(t *testing.T) {
+	engine := score.NewEngine(nil)
+	m := NewManager(engine, nil)
+	if m.Engine() != engine {
+		t.Error("Engine() did not return the wrapped engine")
+	}
+}
+
+func TestManager_NilConfigUsesDefaults(t *testing.T) {
+	engine := score.NewEngine(nil)
+	m := NewManager(engine, nil) // nil config
+	if m.maxSessions != 10000 {
+		t.Errorf("default MaxSessions = %d, want 10000", m.maxSessions)
+	}
+	if m.maxSessionAge != 24*time.Hour {
+		t.Errorf("default MaxSessionAge = %v, want 24h", m.maxSessionAge)
+	}
+}
+
+func TestManager_NilEngineCreatesDefault(t *testing.T) {
+	m := NewManager(nil, nil) // nil engine
+	if m.Engine() == nil {
+		t.Error("NewManager(nil, nil) should create a default engine")
+	}
+}
+
+// TestManager_ConcurrentAccess is a stress test for the race detector.
+// It runs many goroutines creating/recording/ending sessions to
+// catch any race in the mutex-protected paths.
+func TestManager_ConcurrentAccess(t *testing.T) {
+	m := newTestManager(t)
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			agentID := "agent-" + string(rune('0'+idx))
+			sess, err := m.Start(ctx, agentID)
+			if err != nil {
+				t.Errorf("Start: %v", err)
+				return
+			}
+			for j := 0; j < 10; j++ {
+				_, _ = m.Record(ctx, sess.ID, score.EventCapabilityAllowed, "read", 1, "test")
+			}
+			_, _ = m.End(ctx, sess.ID)
+		}(i)
+	}
+	wg.Wait()
+	// 10 active sessions (all just created and ended, all in memory
+	// because MaxSessionAge is 1h).
+	if m.TotalCount() != 10 {
+		t.Errorf("TotalCount = %d, want 10", m.TotalCount())
+	}
+}
+
+// TestManager_SessionIDFormat verifies the ID is a UUID (8-4-4-4-12).
+// This is a sanity check on the uuid library import.
+func TestManager_SessionIDFormat(t *testing.T) {
+	m := newTestManager(t)
+	sess, _ := m.Start(context.Background(), "agent")
+	parts := strings.Split(sess.ID, "-")
+	if len(parts) != 5 {
+		t.Errorf("session ID %q is not a UUID (expected 5 parts, got %d)", sess.ID, len(parts))
+	}
+}


### PR DESCRIPTION
v3.2.0 Phase 4 sub-phases 4.1 and 4.2.

## What's in this PR

### Phase 4.1: Feature gate (commit 4c4cc0d)
- Adds `FeatureTrustPillar` constant (`trust_pillar` key) in pkg/tier/tier.go.
- Maps to TierProfessional in RequiredTier, per locked decision Q3.
- Adds 'trust_pillar' to featureKeyMap.
- 2 new test functions (TestTrustPillar_TierMapping, TestTrustPillar_FeatureKey).
- Coverage: 100.0% on pkg/tier.

### Phase 4.2: Session manager (commit e85c600)
- New file pkg/trust/session.go (372 lines): per-session trust accumulator.
- Session struct: ID, AgentID, StartedAt, EndedAt, InitialScore, Events, Metadata.
- Manager: Start, StartWithMetadata, Get, End, Record, Score, ScoreDelta, List, ListByAgent, ActiveCount, TotalCount, eviction.
- Wraps score.Engine: the session API gives request-lifecycle semantics on top of the agent-lifetime scoring.
- New file pkg/trust/session_test.go (411 lines, 20 test functions).
- Coverage: 100% on session.go; pkg/trust at 91.3%.

## Why this matters

The Trust Framework is the 5th architectural pillar of the AegisGate Platform. It provides cryptographic agent identity, per-session trust scoring, and signed attestations. Phase 4.1 establishes the feature gate (Professional+ per Q3 lock); Phase 4.2 builds the session lifecycle API that the HTTP handlers (4.3) and protocol wiring (4.4) will consume.

## Locked decisions

- Q3: Trust Framework feature gate = Professional+ ✅
- Q6: per-phase branches ✅ (this PR is `feature/trust-framework-5th-pillar`)

## Out of scope (next PRs in this phase)

- 4.3: pkg/trust/api.go (HTTP handlers)
- 4.4: wire trust attestation in mcpserver/a2a/proxy/response
- 4.5: README.md 5-pillar architecture diagram
- 4.6: CHANGELOG entry under v3.2.0

## Test results

- `go test -count=1 -cover ./pkg/trust/` -> PASS, 91.3% cov
- `go test -count=1 -race ./pkg/trust/`  -> PASS, no races
- `go test -count=1 -timeout 180s ./pkg/...` -> PASS, no regressions
- `gofmt -l` -> clean
- `go vet` -> clean

Refs: plans/V3.2.0-ROADMAP.md Section 3 Phase 4
Refs: aegisgate-v3.2.0-locked-decisions.txt (Q3)