### PR TITLE
feat(billing): Pro tier price change $249 -> $499 (v3.2.0 Phase 2)

### DIFF
--- a/pkg/billing/billing-config.example.json
+++ b/pkg/billing/billing-config.example.json
@@ -1,12 +1,12 @@
 {
-  "_comment": "v3.2.0 Phase 1.4: example/template file. Copy to billing-config.json. All 6 module Stripe Price IDs are now live (filled in 2026-06-05); the live billing-config.json has the same values. The example is a reference; the live file is the source of truth at runtime.",
+  "_comment": "v3.2.0 Phase 1.4 + 2: example/template. Pro price is $499/mo, $4990/yr. Copy to billing-config.json for live use.",
   "tier_prices": {
     "starter_annual": 29000,
     "starter_monthly": 2900,
     "developer_annual": 79000,
     "developer_monthly": 7900,
-    "professional_annual": 249000,
-    "professional_monthly": 24900
+    "professional_annual": 499000,
+    "professional_monthly": 49900
   },
   "tier_products": {
     "starter_annual": {
@@ -34,16 +34,16 @@
       "buy_button_id": "buy_btn_1TezBqK2DQfk64XN7Y79VYM7"
     },
     "professional_annual": {
-      "price_id": "price_1Teyy3K2DQfk64XNMZegA40j",
-      "product_id": "prod_UeHXC3v0los7cZ",
+      "price_id": "price_1Tf6NwK2DQfk64XNcsYRFodX",
+      "product_id": "prod_UePCqLsvxE9Ve4",
       "lookup_key": "tier_professional_annual",
-      "buy_button_id": "buy_btn_1TezHkK2DQfk64XN78H7ahQ9"
+      "buy_button_id": "buy_btn_1Tf6VcK2DQfk64XNyG8vnU5X"
     },
     "professional_monthly": {
-      "price_id": "price_1TeyxdK2DQfk64XNO23ktikg",
-      "product_id": "prod_UeHWXXQHJ83JXW",
+      "price_id": "price_1Tf6NWK2DQfk64XNNosvo3H6A",
+      "product_id": "prod_UePBERSjp7tWwg",
       "lookup_key": "tier_professional_monthly",
-      "buy_button_id": "buy_btn_1TezFrK2DQfk64XNRXo9N2rF"
+      "buy_button_id": "buy_btn_1Tf6RqK2DQfk64XNJId23XtS"
     },
     "enterprise": ""
   },

--- a/pkg/billing/billing-config.json
+++ b/pkg/billing/billing-config.json
@@ -1,12 +1,12 @@
 {
-  "_comment_v3.2.0": "v3.2.0 Phase 1.4: Updated with live Stripe Price IDs (2026-06-05). Tier Prices and 6 module Prices are all live in the Stripe dashboard. The webhook (Phase 1.3) reads lookup_key and unit_amount from the line item directly. Price IDs in this file are for invoice/audit-trail reconciliation and the customer portal.",
+  "_comment_v3.2.0": "v3.2.0 Phase 1.4: tier Price IDs and module products. v3.2.0 Phase 2 (2026-06-05): Pro tier price change $249->$499/mo, $2490->$4990/yr. Corrected Stripe IDs after the $399 typo. Existing Pro customers: grandfathered at $249 if any (none at this release; Q2: lock-in at purchase price applies to modules). Webhook (Phase 1.3) reads lookup_key and unit_amount from the line item directly; Price IDs in this file are for invoice/audit-trail reconciliation and the customer portal.",
   "tier_prices": {
     "starter_annual": 29000,
     "starter_monthly": 2900,
     "developer_annual": 79000,
     "developer_monthly": 7900,
-    "professional_annual": 249000,
-    "professional_monthly": 24900
+    "professional_annual": 499000,
+    "professional_monthly": 49900
   },
   "tier_products": {
     "starter_annual": {
@@ -34,16 +34,16 @@
       "buy_button_id": "buy_btn_1TezBqK2DQfk64XN7Y79VYM7"
     },
     "professional_annual": {
-      "price_id": "price_1Teyy3K2DQfk64XNMZegA40j",
-      "product_id": "prod_UeHXC3v0los7cZ",
+      "price_id": "price_1Tf6NwK2DQfk64XNcsYRFodX",
+      "product_id": "prod_UePCqLsvxE9Ve4",
       "lookup_key": "tier_professional_annual",
-      "buy_button_id": "buy_btn_1TezHkK2DQfk64XN78H7ahQ9"
+      "buy_button_id": "buy_btn_1Tf6VcK2DQfk64XNyG8vnU5X"
     },
     "professional_monthly": {
-      "price_id": "price_1TeyxdK2DQfk64XNO23ktikg",
-      "product_id": "prod_UeHWXXQHJ83JXW",
+      "price_id": "price_1Tf6NWK2DQfk64XNNosvo3H6A",
+      "product_id": "prod_UePBERSjp7tWwg",
       "lookup_key": "tier_professional_monthly",
-      "buy_button_id": "buy_btn_1TezFrK2DQfk64XNRXo9N2rF"
+      "buy_button_id": "buy_btn_1Tf6RqK2DQfk64XNJId23XtS"
     },
     "enterprise": ""
   },

--- a/pkg/billing/billing_config_schema_test.go
+++ b/pkg/billing/billing_config_schema_test.go
@@ -304,3 +304,79 @@ func TestBillingConfig_NoPlaceholders(t *testing.T) {
 		})
 	}
 }
+
+// TestBillingConfig_ProPriceIsLocked pins the Professional tier at $499/mo,
+// $4990/yr per the v3.2.0 Phase 2 decision. Update this test if the
+// pricing table changes.
+func TestBillingConfig_ProPriceIsLocked(t *testing.T) {
+	data, err := os.ReadFile("billing-config.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var v struct {
+		TierPrices map[string]int `json:"tier_prices"`
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	cases := []struct {
+		key  string
+		want int
+		desc string
+	}{
+		{"professional_monthly", 49900, "$499/mo"},
+		{"professional_annual", 499000, "$4990/yr"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			got, ok := v.TierPrices[tc.key]
+			if !ok {
+				t.Fatalf("missing key %s", tc.key)
+			}
+			if got != tc.want {
+				t.Errorf("%s = %d cents ($%.2f), want %d cents (%s)",
+					tc.key, got, float64(got)/100, tc.want, tc.desc)
+			}
+		})
+	}
+}
+
+// TestBillingConfig_ProPriceIDsAreCurrent pins the current Pro Stripe
+// Price IDs. Update this test if the Stripe Prices are regenerated.
+func TestBillingConfig_ProPriceIDsAreCurrent(t *testing.T) {
+	data, err := os.ReadFile("billing-config.json")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var v struct {
+		TierProducts map[string]struct {
+			PriceID     string `json:"price_id"`
+			BuyButtonID string `json:"buy_button_id"`
+		} `json:"tier_products"`
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	cases := []struct {
+		key        string
+		wantPrice  string
+		wantButton string
+	}{
+		{"professional_monthly", "price_1Tf6NWK2DQfk64XNNosvo3H6A", "buy_btn_1Tf6RqK2DQfk64XNJId23XtS"},
+		{"professional_annual", "price_1Tf6NwK2DQfk64XNcsYRFodX", "buy_btn_1Tf6VcK2DQfk64XNyG8vnU5X"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
+			got, ok := v.TierProducts[tc.key]
+			if !ok {
+				t.Fatalf("missing key %s", tc.key)
+			}
+			if got.PriceID != tc.wantPrice {
+				t.Errorf("price_id = %q, want %q", got.PriceID, tc.wantPrice)
+			}
+			if got.BuyButtonID != tc.wantButton {
+				t.Errorf("buy_button_id = %q, want %q", got.BuyButtonID, tc.wantButton)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## v3.2.0 Phase 2 — Pro Tier Price Change

Implements the Pro tier price change from $249/mo to $499/mo. The Stripe
dashboard has 2 new Prices ($499/mo recurring, $4990/yr one-time)
under the new Pro products; billing-config.json captures the new IDs.

### What's in this PR

- `pkg/billing/billing-config.json`: Pro tier cents + Stripe IDs
- `pkg/billing/billing-config.example.json`: same template
- `pkg/billing/billing_config_schema_test.go`: 2 new tests pin
  the locked $499 price and the new Stripe IDs

### Grandfathering

No Pro customers exist at the time of this release, so the
grandfathering code path (Q2: lock-in at purchase price forever)
is unexercised. The policy is documented in the file's top
comment. If any customer buys Pro after this PR lands, they pay
$499; future price changes won't affect them.

### Test results

- 8 schema tests (6 prior + 2 new) all pass
- Full `pkg/...` suite: no regressions
- gofmt + go vet: clean

Refs: plans/V3.2.0-ROADMAP.md Section 3 Phase 2
Refs: aegisgate-v3.2.0-locked-decisions.txt (Q2)