### PR TITLE
Platform: add #nosec G703 annotation to copyVendorDocs os.Stat

### DIFF
--- a/tools/build-lens-extension/bundle.go
+++ b/tools/build-lens-extension/bundle.go
@@ -181,7 +181,7 @@ func copyTree(srcRoot, dstRoot, ext string) (int, error) {
 // threat-model documentation (SHA-256 pins).
 func copyVendorDocs(srcRoot, dstRoot string) (int, error) {
 	vendorDir := filepath.Join(srcRoot, "vendor")
-	info, err := os.Stat(vendorDir)
+	info, err := os.Stat(vendorDir) // #nosec G703 -- vendorDir is derived from the developer-supplied --src tree (same pattern as copyDirIfExists at line 244)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return 0, nil


### PR DESCRIPTION
Fixes the remaining G703 alert that was still firing on main after PR #77 was merged.

The previous fix (commit 833602f in PR #77) added isSafePathComponent() checks for entry.Name and f.Name but missed annotating the initial os.Stat(vendorDir) call at line 184. The vendorDir is derived from the developer-supplied --src tree argument (same source as copyDirIfExists which already has a #nosec G703 at line 244).

This commit adds the matching #nosec annotation. The actual security is already enforced by isSafePathComponent on the names that come from the directory listing.

After this commit, the G703 alert should auto-resolve on the next code-scanning run on main.

Signed-off-by: AegisGate Security <security@aegisgatesecurity.io>