### PR TITLE
Platform: silence G304/G204 in pkg/lenstest test harness

### DIFF
--- a/pkg/lenstest/detector/detector.go
+++ b/pkg/lenstest/detector/detector.go
@@ -105,7 +105,7 @@ func (d *Detector) DetectBatch(ctx context.Context, prompts []string) ([]DetectR
 	}
 
 	// Build command
-	cmd := exec.CommandContext(ctx, d.NodePath, d.Script)
+	cmd := exec.CommandContext(ctx, d.NodePath, d.Script) // #nosec G204 -- d.NodePath and d.Script are from the test harness config (set by the test runner), not user input
 	cmd.Env = append(os.Environ(),
 		"LENS_DIST_ROOT="+d.DistRoot,
 	)

--- a/pkg/lenstest/goside/goside.go
+++ b/pkg/lenstest/goside/goside.go
@@ -128,7 +128,7 @@ func New(platformRoot string) (*Detector, error) {
 // the deriveOwaspCategory function. We replicate the same mapping
 // here so that Go-side category names match JS detector names.
 func extractOwaspFile(path string) ([]PatternDef, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from filepath.WalkDir on the test corpus directory; not user input
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func owaspCategoryMap(category string) string {
 // with "atlas_" (e.g., "atlas_promptinjection"). This matches the
 // JS detector's category names.
 func extractAtlasFile(path string) ([]PatternDef, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from filepath.WalkDir on the test corpus directory; not user input
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func extractAtlasFile(path string) ([]PatternDef, error) {
 // Shape: varName = []*regexp.Regexp{ regexp.MustCompile(`...`), ... }
 // All regexes in a slice get the same source category.
 func extractNamedSliceFile(path, source, frameworkName string) ([]PatternDef, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from filepath.WalkDir on the test corpus directory; not user input
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func extractNamedSliceFile(path, source, frameworkName string) ([]PatternDef, er
 // just need regex strings and the surrounding variable name.
 // Output is suitable for direct comparison to the JS patterns.
 func extractFromFile(path, source string) ([]PatternDef, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- path comes from filepath.WalkDir on the test corpus directory; not user input
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Addresses 5 of the 6 remaining code-scanning alerts on main.

The pkg/lenstest Phase 4 test corpus harness was newly committed in PR #77. CodeQL flagged 4 G304 (file inclusion via variable) and 1 G204 (subprocess with tainted input) in the test harness code. These are false positives — the test harness operates on a developer-supplied test corpus directory, not user input.

All 5 changes are \#nosec annotations with justifications. No behavioral change.

After this PR:
- Alert count: 6 → 1 (the only remaining is CVE-2024-24786 in upstream/aegisguard/go.mod)

Signed-off-by: AegisGate Security <security@aegisgatesecurity.io>